### PR TITLE
Fix the File inclusion as reported by Ali Khalil.

### DIFF
--- a/admin/includes/mobile_themes/mTheme-Unus/css/css.php
+++ b/admin/includes/mobile_themes/mTheme-Unus/css/css.php
@@ -11,6 +11,11 @@ if (!isset($_GET['files']) or strlen($_GET['files']) == 0)
 	exit();
 }
 
+if (strcmp(pathinfo($_GET['files'], PATHINFO_EXTENSION), "css") !== 0) {
+   exit();
+}
+
+
 // Cache folder
 $cachePath = '../_cache/';
 if (!file_exists($cachePath))


### PR DESCRIPTION
Prevent using files variable to point to non-css file such as PHP files. This was reported by Ali Khalil, who said that it was possible to make a request such as:

site.com/wp-content/themes/mTheme-Unus/css/css.php?files=../../../../wp-config.php

Since the aim is process CSS files only, the files variable should only contain files that end with .css.
